### PR TITLE
feat(global): Refresh Token 관리 및 서버 기본 설정(보안, CORS, JPA) 추가

### DIFF
--- a/src/main/kotlin/ac/dnd/server/account/infrastructure/persistence/entity/RefreshToken.kt
+++ b/src/main/kotlin/ac/dnd/server/account/infrastructure/persistence/entity/RefreshToken.kt
@@ -1,0 +1,35 @@
+package ac.dnd.server.account.infrastructure.persistence.entity
+
+import ac.dnd.server.shared.persistence.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Embedded
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "refresh_token")
+class RefreshToken(
+    @Embedded
+    val userKey: UserKey,
+
+    @Column(nullable = false, unique = true)
+    var token: String,
+
+    @Column(name = "expires_at", nullable = false)
+    var expiresAt: LocalDateTime,
+
+    var expired: Boolean = false
+) : BaseEntity() {
+
+    protected constructor() : this(UserKey.generate(), "", LocalDateTime.now())
+
+    fun isExpired(): Boolean {
+        return LocalDateTime.now().isAfter(expiresAt) || expired
+    }
+
+    fun updateToken(newToken: String, expiresAt: LocalDateTime) {
+        this.token = newToken
+        this.expiresAt = expiresAt
+    }
+}

--- a/src/main/kotlin/ac/dnd/server/account/infrastructure/persistence/repository/RefreshTokenRepository.kt
+++ b/src/main/kotlin/ac/dnd/server/account/infrastructure/persistence/repository/RefreshTokenRepository.kt
@@ -1,0 +1,10 @@
+package ac.dnd.server.account.infrastructure.persistence.repository
+
+import ac.dnd.server.account.infrastructure.persistence.entity.RefreshToken
+import ac.dnd.server.account.infrastructure.persistence.entity.UserKey
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface RefreshTokenRepository : JpaRepository<RefreshToken, Long> {
+    fun findByToken(token: String): RefreshToken?
+    fun findByUserKey(userKey: UserKey): RefreshToken?
+}

--- a/src/main/kotlin/ac/dnd/server/admission/infrastructure/config/HmacConfig.kt
+++ b/src/main/kotlin/ac/dnd/server/admission/infrastructure/config/HmacConfig.kt
@@ -1,0 +1,17 @@
+package ac.dnd.server.admission.infrastructure.config
+
+import ac.dnd.server.admission.infrastructure.persistence.crypto.HmacBlindIndexCreator
+import ac.dnd.server.shared.config.properties.EncryptionProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class HmacConfig(
+    private val encryptionProperties: EncryptionProperties,
+) {
+
+    @Bean
+    fun hmacBlindIndexCreator(): HmacBlindIndexCreator {
+        return HmacBlindIndexCreator(encryptionProperties)
+    }
+}

--- a/src/main/kotlin/ac/dnd/server/shared/config/crypto/TextEncryptorConfig.kt
+++ b/src/main/kotlin/ac/dnd/server/shared/config/crypto/TextEncryptorConfig.kt
@@ -1,0 +1,21 @@
+package ac.dnd.server.shared.config.crypto
+
+import ac.dnd.server.shared.config.properties.EncryptionProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.crypto.encrypt.Encryptors
+import org.springframework.security.crypto.encrypt.TextEncryptor
+
+@Configuration
+class TextEncryptorConfig(
+    private val encryptionProperties: EncryptionProperties,
+) {
+
+    @Bean
+    fun textEncryptor(): TextEncryptor {
+        return Encryptors.text(
+            encryptionProperties.aes.password,
+            encryptionProperties.aes.salt,
+        )
+    }
+}

--- a/src/main/kotlin/ac/dnd/server/shared/config/web/CorsConfig.kt
+++ b/src/main/kotlin/ac/dnd/server/shared/config/web/CorsConfig.kt
@@ -1,0 +1,30 @@
+package ac.dnd.server.shared.config.web
+
+import ac.dnd.server.shared.config.properties.CorsProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.cors.CorsConfiguration
+import org.springframework.web.cors.CorsConfigurationSource
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource
+
+@Configuration
+class CorsConfig(
+    private val corsProperties: CorsProperties,
+) {
+
+    @Bean
+    fun corsConfigurationSource(): CorsConfigurationSource {
+        val corsConfiguration = CorsConfiguration().apply {
+            allowedOriginPatterns = corsProperties.allowedOriginsPatterns
+            allowedHeaders = corsProperties.allowedHeaders
+            exposedHeaders = corsProperties.exposedHeaders
+            allowCredentials = corsProperties.allowCredentials
+            maxAge = corsProperties.maxAge
+            allowedMethods = corsProperties.allowedMethods
+        }
+
+        return UrlBasedCorsConfigurationSource().apply {
+            registerCorsConfiguration("/**", corsConfiguration)
+        }
+    }
+}

--- a/src/main/kotlin/ac/dnd/server/shared/persistence/JpaAuditingConfig.kt
+++ b/src/main/kotlin/ac/dnd/server/shared/persistence/JpaAuditingConfig.kt
@@ -1,0 +1,34 @@
+package ac.dnd.server.shared.persistence
+
+import ac.dnd.server.account.infrastructure.security.authentication.userdetails.AccountDetails
+import ac.dnd.server.shared.dto.LoginInfo
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.domain.AuditorAware
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing
+import org.springframework.security.core.context.SecurityContextHolder
+import java.util.Optional
+import java.util.UUID
+
+@Configuration
+@EnableJpaAuditing
+class JpaAuditingConfig {
+
+    @Bean
+    fun auditorAware(): AuditorAware<UUID> = SecurityAuditorAware()
+}
+
+class SecurityAuditorAware : AuditorAware<UUID> {
+    override fun getCurrentAuditor(): Optional<UUID> {
+        val authentication = SecurityContextHolder.getContext().authentication ?: return Optional.empty()
+        if (!authentication.isAuthenticated) return Optional.empty()
+
+        val principal = authentication.principal
+        return when (principal) {
+            is AccountDetails -> Optional.of(principal.userKey)
+            is LoginInfo -> Optional.of(principal.userId)
+            is UUID -> Optional.of(principal)
+            else -> Optional.empty()
+        }
+    }
+}


### PR DESCRIPTION
Refresh Token 관리 및 서버 기본 설정(보안, CORS, JPA) 추가
- 인증 토큰 관리를 위한 RefreshToken Entity, Repository 구현
- 데이터 암호화 및 전역 CORS 설정 클래스 위치 리팩토링 
- 엔티티 변경 감지를 위한 JPA Auditing 설정 및 SecurityContext 기반 AuditorAware 구현
