### PR TITLE
feat(security): 로그아웃 API 추가

### DIFF
--- a/src/main/kotlin/ac/dnd/server/account/infrastructure/persistence/repository/RefreshTokenRepository.kt
+++ b/src/main/kotlin/ac/dnd/server/account/infrastructure/persistence/repository/RefreshTokenRepository.kt
@@ -7,4 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 interface RefreshTokenRepository : JpaRepository<RefreshToken, Long> {
     fun findByToken(token: String): RefreshToken?
     fun findByUserKey(userKey: UserKey): RefreshToken?
+    fun deleteByUserKey(userKey: UserKey)
 }

--- a/src/main/kotlin/ac/dnd/server/account/infrastructure/web/AuthController.kt
+++ b/src/main/kotlin/ac/dnd/server/account/infrastructure/web/AuthController.kt
@@ -1,0 +1,42 @@
+package ac.dnd.server.account.infrastructure.web
+
+import ac.dnd.server.account.infrastructure.persistence.entity.UserKey
+import ac.dnd.server.account.infrastructure.persistence.repository.RefreshTokenRepository
+import ac.dnd.server.shared.annotation.AuthUser
+import ac.dnd.server.shared.dto.LoginInfo
+import jakarta.servlet.http.Cookie
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.ResponseEntity
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/auth")
+class AuthController(
+    private val refreshTokenRepository: RefreshTokenRepository
+) {
+
+    @PostMapping("/logout")
+    @Transactional
+    fun logout(
+        @AuthUser loginInfo: LoginInfo,
+        response: HttpServletResponse
+    ): ResponseEntity<Map<String, String>> {
+        refreshTokenRepository.deleteByUserKey(UserKey(loginInfo.userId))
+
+        response.addCookie(createExpiredRefreshTokenCookie())
+
+        return ResponseEntity.ok(mapOf("message" to "Logout successful"))
+    }
+
+    private fun createExpiredRefreshTokenCookie(): Cookie {
+        return Cookie("refreshToken", "").apply {
+            isHttpOnly = true
+            secure = false
+            path = "/"
+            maxAge = 0
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- 로그아웃 API 엔드포인트 추가
- Refresh Token 삭제 처리

## Test plan
- [ ] 로그아웃 API 호출 시 Refresh Token이 삭제되는지 확인
- [ ] 로그아웃 후 기존 Refresh Token으로 갱신 불가능한지 확인