### PR TITLE
test : 인증, JWT, 지원자 도메인에 대한 단위 테스트 및 통합 테스트 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Run tests with coverage
+        run: ./gradlew test koverXmlReport
+        env:
+          DOCKER_API_VERSION: '1.44'
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: build/reports/kover/report.xml
+          fail_ci_if_error: false
+          verbose: true

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ plugins {
     id 'io.spring.dependency-management' version '1.1.7'
     id 'org.asciidoctor.jvm.convert' version '4.0.4'
     id "com.epages.restdocs-api-spec" version "0.19.4"
+    id 'org.jetbrains.kotlinx.kover' version '0.9.1'
 }
 
 group = 'ac.dnd'
@@ -76,9 +77,7 @@ dependencies {
     testImplementation 'org.mockito.kotlin:mockito-kotlin:5.1.0'
 
     // Documentation - Springdoc OpenAPI (Swagger UI)
-    implementation("org.springdoc:springdoc-openapi-ui:1.8.0")
-    implementation("org.springdoc:springdoc-openapi-webmvc-core:1.8.0")
-
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0")
     // Documentation - Spring REST Docs & OpenAPI Spec
     testImplementation("org.springframework.restdocs:spring-restdocs-mockmvc")
     testImplementation("com.epages:restdocs-api-spec-mockmvc:${dependencyManagement.importedProperties['restdocs-api-spec.version'] ?: '0.19.4'}")
@@ -90,6 +89,8 @@ dependencies {
 tasks.named('test') {
     outputs.dir snippetsDir
     useJUnitPlatform()
+    jvmArgs("-XX:+EnableDynamicAgentLoading")
+    environment 'DOCKER_API_VERSION', '1.44'
 }
 
 tasks.register("restDocsTest", Test) {
@@ -97,6 +98,7 @@ tasks.register("restDocsTest", Test) {
     useJUnitPlatform {
         includeTags("restDocs")
     }
+    jvmArgs("-XX:+EnableDynamicAgentLoading")
     finalizedBy "asciidoctor"
     finalizedBy "openapi3"
 }
@@ -110,6 +112,7 @@ tasks.named('asciidoctor') {
 }
 
 bootJar {
+    dependsOn asciidoctor
     from("swagger-ui") {
         into "BOOT-INF/classes/static/swagger"
     }
@@ -120,4 +123,17 @@ bootJar {
         into "BOOT-INF/classes/static/swagger"
     }
     archiveFileName.set("app.jar")
+}
+
+kover {
+    reports {
+        filters {
+            excludes {
+                classes(
+                        "ac.dnd.server.DndServerApplication*",
+                        "*.config.*"
+                )
+            }
+        }
+    }
 }

--- a/src/main/kotlin/ac/dnd/server/account/infrastructure/security/authentication/filter/JsonUsernamePasswordAuthenticationFilter.kt
+++ b/src/main/kotlin/ac/dnd/server/account/infrastructure/security/authentication/filter/JsonUsernamePasswordAuthenticationFilter.kt
@@ -20,9 +20,9 @@ class JsonUsernamePasswordAuthenticationFilter(
             throw AuthenticationServiceException("Authentication content-type not supported: ${request.contentType}")
         }
 
-        val request = objectMapper.readValue(request.inputStream, UserLoginRequest::class.java)
-        val username = request.email
-        val password = request.password
+        val userRequest = objectMapper.readValue(request.inputStream, UserLoginRequest::class.java)
+        val username = userRequest.email
+        val password = userRequest.password
 
         if (username.isNullOrBlank() || password.isNullOrBlank()) {
             throw AuthenticationServiceException("Username or Password not provided")

--- a/src/main/kotlin/ac/dnd/server/account/infrastructure/security/authentication/handler/RestAuthSuccessHandler.kt
+++ b/src/main/kotlin/ac/dnd/server/account/infrastructure/security/authentication/handler/RestAuthSuccessHandler.kt
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import jakarta.servlet.http.Cookie
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.security.core.Authentication
@@ -77,6 +78,7 @@ class RestAuthSuccessHandler(
         response.status = HttpStatus.OK.value()
         response.contentType = MediaType.APPLICATION_JSON_VALUE
         response.characterEncoding = "UTF-8"
+        response.addHeader(HttpHeaders.AUTHORIZATION, "Bearer $accessToken")
 
         val loginResponse = LoginResponse(
             accessToken = accessToken,

--- a/src/test/kotlin/ac/dnd/server/account/infrastructure/persistence/entity/RefreshTokenTest.kt
+++ b/src/test/kotlin/ac/dnd/server/account/infrastructure/persistence/entity/RefreshTokenTest.kt
@@ -1,0 +1,77 @@
+package ac.dnd.server.account.infrastructure.persistence.entity
+
+import ac.dnd.server.annotation.UnitTest
+import ac.dnd.server.fixture.RefreshTokenFixture
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import java.time.LocalDateTime
+
+@UnitTest
+class RefreshTokenTest : DescribeSpec({
+
+    describe("isExpired") {
+
+        it("만료 시간이 지나면 true를 반환한다") {
+            // given
+            val refreshToken = RefreshTokenFixture.createExpiredByTime()
+
+            // when
+            val result = refreshToken.isExpired()
+
+            // then
+            result shouldBe true
+        }
+
+        it("expired 플래그가 true이면 만료 시간과 관계없이 true를 반환한다") {
+            // given
+            val refreshToken = RefreshTokenFixture.createExpiredByFlag()
+
+            // when
+            val result = refreshToken.isExpired()
+
+            // then
+            result shouldBe true
+        }
+
+        it("만료 시간이 지나지 않고 expired 플래그가 false이면 false를 반환한다") {
+            // given
+            val refreshToken = RefreshTokenFixture.createValid()
+
+            // when
+            val result = refreshToken.isExpired()
+
+            // then
+            result shouldBe false
+        }
+    }
+
+    describe("updateToken") {
+
+        it("토큰과 만료 시간을 업데이트한다") {
+            // given
+            val refreshToken = RefreshTokenFixture.createValid()
+            val newToken = "new-refresh-token"
+            val newExpiresAt = LocalDateTime.now().plusDays(60)
+
+            // when
+            refreshToken.updateToken(newToken, newExpiresAt)
+
+            // then
+            refreshToken.token shouldBe newToken
+            refreshToken.expiresAt shouldBe newExpiresAt
+        }
+
+        it("토큰 업데이트 후에도 유효한 상태를 유지한다") {
+            // given
+            val refreshToken = RefreshTokenFixture.createValid()
+            val newToken = "rotated-refresh-token"
+            val newExpiresAt = LocalDateTime.now().plusDays(30)
+
+            // when
+            refreshToken.updateToken(newToken, newExpiresAt)
+
+            // then
+            refreshToken.isExpired() shouldBe false
+        }
+    }
+})

--- a/src/test/kotlin/ac/dnd/server/account/infrastructure/security/LoginIntegrationTest.kt
+++ b/src/test/kotlin/ac/dnd/server/account/infrastructure/security/LoginIntegrationTest.kt
@@ -4,56 +4,26 @@ import ac.dnd.server.account.domain.enums.Role
 import ac.dnd.server.account.infrastructure.persistence.entity.Account
 import ac.dnd.server.account.infrastructure.persistence.repository.AccountJpaRepository
 import ac.dnd.server.account.infrastructure.security.dto.UserLoginRequest
+import ac.dnd.server.annotation.IntegrationTest
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.testcontainers.service.connection.ServiceConnection
 import org.springframework.http.MediaType
 import org.springframework.security.crypto.password.PasswordEncoder
-import org.springframework.test.context.DynamicPropertyRegistry
-import org.springframework.test.context.DynamicPropertySource
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.header
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.springframework.transaction.annotation.Transactional
-import org.testcontainers.containers.MySQLContainer
-import org.testcontainers.junit.jupiter.Container
-import org.testcontainers.junit.jupiter.Testcontainers
 
-@SpringBootTest
+@IntegrationTest
 @AutoConfigureMockMvc
 @Transactional
-@Testcontainers
 class LoginIntegrationTest {
-
-    companion object {
-        @Container
-        @ServiceConnection
-        val mysqlContainer = MySQLContainer<Nothing>("mysql:8.0").apply {
-            withDatabaseName("testdb")
-            withUsername("test")
-            withPassword("test")
-        }
-
-        @JvmStatic
-        @DynamicPropertySource
-        fun properties(registry: DynamicPropertyRegistry) {
-            registry.add("encryption.aes.password") { "testpassword" }
-            registry.add("encryption.aes.salt") { "12345678" }
-            registry.add("encryption.hmac.key") { "12345678" }
-            registry.add("github.token") { "testtoken" }
-            registry.add("github.repository.owner") { "testowner" }
-            registry.add("github.repository.name") { "testname" }
-            registry.add("jwt.secret") { "testSecretKeyForJwtTokenThatIsLongEnoughForHS256Algorithm" }
-            registry.add("jwt.accessTokenExpirationHours") { "1" }
-            registry.add("jwt.refreshTokenExpirationDays") { "30" }
-        }
-    }
 
     @Autowired
     private lateinit var mockMvc: MockMvc
@@ -89,8 +59,7 @@ class LoginIntegrationTest {
                 .content(objectMapper.writeValueAsString(loginRequest))
         )
             .andDo(MockMvcResultHandlers.print())
-            .andExpect(status().isOk)
-            .andExpect(jsonPath("$.message").value("Login successful"))
+            .andExpect(header().exists("Authorization"))
     }
 
     @Test

--- a/src/test/kotlin/ac/dnd/server/account/infrastructure/security/RefreshTokenIntegrationTest.kt
+++ b/src/test/kotlin/ac/dnd/server/account/infrastructure/security/RefreshTokenIntegrationTest.kt
@@ -1,5 +1,6 @@
 package ac.dnd.server.account.infrastructure.security
 
+import ac.dnd.server.annotation.IntegrationTest
 import ac.dnd.server.account.domain.enums.Role
 import ac.dnd.server.account.infrastructure.persistence.entity.Account
 import ac.dnd.server.account.infrastructure.persistence.repository.AccountJpaRepository
@@ -13,51 +14,19 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.testcontainers.service.connection.ServiceConnection
 import org.springframework.http.MediaType
 import org.springframework.security.crypto.password.PasswordEncoder
-import org.springframework.test.context.DynamicPropertyRegistry
-import org.springframework.test.context.DynamicPropertySource
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
 import org.springframework.transaction.annotation.Transactional
-import org.testcontainers.containers.MySQLContainer
-import org.testcontainers.junit.jupiter.Container
-import org.testcontainers.junit.jupiter.Testcontainers
 
-@SpringBootTest
+@IntegrationTest
 @AutoConfigureMockMvc
 @Transactional
-@Testcontainers
 class RefreshTokenIntegrationTest {
-
-    companion object {
-        @Container
-        @ServiceConnection
-        val mysqlContainer = MySQLContainer<Nothing>("mysql:8.0").apply {
-            withDatabaseName("testdb")
-            withUsername("test")
-            withPassword("test")
-        }
-
-        @JvmStatic
-        @DynamicPropertySource
-        fun properties(registry: DynamicPropertyRegistry) {
-            registry.add("encryption.aes.password") { "testpassword" }
-            registry.add("encryption.aes.salt") { "12345678" }
-            registry.add("encryption.hmac.key") { "12345678" }
-            registry.add("github.token") { "testtoken" }
-            registry.add("github.repository.owner") { "testowner" }
-            registry.add("github.repository.name") { "testname" }
-            registry.add("jwt.secret") { "testSecretKeyForJwtTokenThatIsLongEnoughForHS256Algorithm" }
-            registry.add("jwt.accessTokenExpirationHours") { "1" }
-            registry.add("jwt.refreshTokenExpirationDays") { "30" }
-        }
-    }
 
     @Autowired
     private lateinit var mockMvc: MockMvc

--- a/src/test/kotlin/ac/dnd/server/account/infrastructure/security/jwt/JwtTokenProviderTest.kt
+++ b/src/test/kotlin/ac/dnd/server/account/infrastructure/security/jwt/JwtTokenProviderTest.kt
@@ -1,0 +1,164 @@
+package ac.dnd.server.account.infrastructure.security.jwt
+
+import ac.dnd.server.annotation.UnitTest
+import ac.dnd.server.fixture.JwtPropertiesFixture
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldNotBeEmpty
+import java.util.UUID
+
+@UnitTest
+class JwtTokenProviderTest : DescribeSpec({
+
+    val jwtProperties = JwtPropertiesFixture.create()
+    val jwtTokenProvider = JwtTokenProvider(jwtProperties)
+
+    describe("generateAccessToken") {
+
+        it("유효한 Access Token을 생성한다") {
+            // given
+            val userKey = UUID.randomUUID()
+            val email = "test@example.com"
+            val role = "ADMIN"
+
+            // when
+            val token = jwtTokenProvider.generateAccessToken(userKey, email, role)
+
+            // then
+            token.shouldNotBeEmpty()
+            jwtTokenProvider.validateToken(token) shouldBe true
+        }
+
+        it("생성된 토큰에서 userKey를 추출할 수 있다") {
+            // given
+            val userKey = UUID.randomUUID()
+            val email = "test@example.com"
+            val role = "ADMIN"
+
+            // when
+            val token = jwtTokenProvider.generateAccessToken(userKey, email, role)
+
+            // then
+            jwtTokenProvider.extractUserKey(token) shouldBe userKey
+        }
+
+        it("생성된 토큰에서 email을 추출할 수 있다") {
+            // given
+            val userKey = UUID.randomUUID()
+            val email = "test@example.com"
+            val role = "ADMIN"
+
+            // when
+            val token = jwtTokenProvider.generateAccessToken(userKey, email, role)
+
+            // then
+            jwtTokenProvider.extractEmail(token) shouldBe email
+        }
+
+        it("생성된 토큰에서 role을 추출할 수 있다") {
+            // given
+            val userKey = UUID.randomUUID()
+            val email = "test@example.com"
+            val role = "ADMIN"
+
+            // when
+            val token = jwtTokenProvider.generateAccessToken(userKey, email, role)
+
+            // then
+            jwtTokenProvider.extractRole(token) shouldBe role
+        }
+    }
+
+    describe("generateRefreshToken") {
+
+        it("유효한 Refresh Token을 생성한다") {
+            // given
+            val userKey = UUID.randomUUID()
+
+            // when
+            val token = jwtTokenProvider.generateRefreshToken(userKey)
+
+            // then
+            token.shouldNotBeEmpty()
+            jwtTokenProvider.validateToken(token) shouldBe true
+        }
+
+        it("생성된 Refresh Token에서 userKey를 추출할 수 있다") {
+            // given
+            val userKey = UUID.randomUUID()
+
+            // when
+            val token = jwtTokenProvider.generateRefreshToken(userKey)
+
+            // then
+            jwtTokenProvider.extractUserKey(token) shouldBe userKey
+        }
+
+        it("Access Token과 Refresh Token은 서로 다른 값이다") {
+            // given
+            val userKey = UUID.randomUUID()
+            val email = "test@example.com"
+            val role = "ADMIN"
+
+            // when
+            val accessToken = jwtTokenProvider.generateAccessToken(userKey, email, role)
+            val refreshToken = jwtTokenProvider.generateRefreshToken(userKey)
+
+            // then
+            accessToken shouldNotBe refreshToken
+        }
+    }
+
+    describe("validateToken") {
+
+        it("유효한 토큰이면 true를 반환한다") {
+            // given
+            val userKey = UUID.randomUUID()
+            val token = jwtTokenProvider.generateRefreshToken(userKey)
+
+            // when
+            val result = jwtTokenProvider.validateToken(token)
+
+            // then
+            result shouldBe true
+        }
+
+        it("잘못된 형식의 토큰이면 false를 반환한다") {
+            // given
+            val invalidToken = "invalid.token.format"
+
+            // when
+            val result = jwtTokenProvider.validateToken(invalidToken)
+
+            // then
+            result shouldBe false
+        }
+
+        it("빈 문자열이면 false를 반환한다") {
+            // given
+            val emptyToken = ""
+
+            // when
+            val result = jwtTokenProvider.validateToken(emptyToken)
+
+            // then
+            result shouldBe false
+        }
+
+        it("다른 secret key로 생성된 토큰이면 false를 반환한다") {
+            // given
+            val otherProperties = JwtPropertiesFixture.create(
+                secret = "other-secret-key-for-jwt-token-generation-must-be-at-least-256-bits"
+            )
+            val otherProvider = JwtTokenProvider(otherProperties)
+            val tokenFromOtherProvider = otherProvider.generateRefreshToken(UUID.randomUUID())
+
+            // when
+            val result = jwtTokenProvider.validateToken(tokenFromOtherProvider)
+
+            // then
+            result shouldBe false
+        }
+    }
+})

--- a/src/test/kotlin/ac/dnd/server/admission/application/service/ApplicantQueryServiceTest.kt
+++ b/src/test/kotlin/ac/dnd/server/admission/application/service/ApplicantQueryServiceTest.kt
@@ -1,0 +1,111 @@
+package ac.dnd.server.admission.application.service
+
+import ac.dnd.server.admission.application.dto.ApplicantStatusCheckCommand
+import ac.dnd.server.admission.domain.AdmissionRepository
+import ac.dnd.server.admission.domain.ApplicantValidator
+import ac.dnd.server.admission.domain.model.ViewablePeriod
+import ac.dnd.server.admission.exception.ApplicantNotFoundException
+import ac.dnd.server.admission.exception.ApplicantViewablePeriodEndException
+import ac.dnd.server.annotation.UnitTest
+import ac.dnd.server.fixture.ApplicantDataFixture
+import ac.dnd.server.shared.event.EventDispatcher
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.context.ApplicationEventPublisher
+import java.time.LocalDateTime
+
+@UnitTest
+class ApplicantQueryServiceTest : DescribeSpec({
+
+    val admissionRepository = mock<AdmissionRepository>()
+    val applicantValidator = mock<ApplicantValidator>()
+    val mockEventPublisher = mock<ApplicationEventPublisher>()
+    val applicantQueryService = ApplicantQueryService(admissionRepository, applicantValidator)
+
+    beforeSpec {
+        EventDispatcher.setApplicationEventPublisher(mockEventPublisher)
+    }
+
+    describe("getApplicantStatusCheck") {
+
+        it("지원자가 존재하고 조회 가능 기간 내이면 ApplicantData를 반환한다") {
+            // given
+            val now = LocalDateTime.now()
+            val command = ApplicantStatusCheckCommand(
+                eventId = 1L,
+                name = "홍길동",
+                email = "test@example.com"
+            )
+            val applicantData = ApplicantDataFixture.createViewable(now)
+
+            whenever(admissionRepository.findAdmissionByEventIdAndNameAndEmail(
+                command.eventId,
+                command.name,
+                command.email
+            )).thenReturn(applicantData)
+
+            // when
+            val result = applicantQueryService.getApplicantStatusCheck(command)
+
+            // then
+            result shouldBe applicantData
+            verify(applicantValidator).viewableValidator(any(), any())
+        }
+
+        it("지원자가 존재하지 않으면 ApplicantNotFoundException이 발생한다") {
+            // given
+            val command = ApplicantStatusCheckCommand(
+                eventId = 1L,
+                name = "존재하지않는이름",
+                email = "notfound@example.com"
+            )
+
+            whenever(admissionRepository.findAdmissionByEventIdAndNameAndEmail(
+                command.eventId,
+                command.name,
+                command.email
+            )).thenReturn(null)
+
+            // when & then
+            shouldThrow<ApplicantNotFoundException> {
+                applicantQueryService.getApplicantStatusCheck(command)
+            }
+        }
+
+        it("조회 가능 기간이 지났으면 ApplicantViewablePeriodEndException이 발생한다") {
+            // given
+            val now = LocalDateTime.now()
+            val command = ApplicantStatusCheckCommand(
+                eventId = 1L,
+                name = "홍길동",
+                email = "test@example.com"
+            )
+            val applicantData = ApplicantDataFixture.create(
+                period = ViewablePeriod.of(
+                    now.minusDays(20),
+                    now.minusDays(10)
+                )
+            )
+
+            whenever(admissionRepository.findAdmissionByEventIdAndNameAndEmail(
+                command.eventId,
+                command.name,
+                command.email
+            )).thenReturn(applicantData)
+
+            doThrow(ApplicantViewablePeriodEndException())
+                .whenever(applicantValidator).viewableValidator(any(), any())
+
+            // when & then
+            shouldThrow<ApplicantViewablePeriodEndException> {
+                applicantQueryService.getApplicantStatusCheck(command)
+            }
+        }
+    }
+})

--- a/src/test/kotlin/ac/dnd/server/admission/domain/ApplicantValidatorTest.kt
+++ b/src/test/kotlin/ac/dnd/server/admission/domain/ApplicantValidatorTest.kt
@@ -1,0 +1,56 @@
+package ac.dnd.server.admission.domain
+
+import ac.dnd.server.admission.exception.ApplicantViewablePeriodEndException
+import ac.dnd.server.annotation.UnitTest
+import ac.dnd.server.fixture.ApplicantDataFixture
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import java.time.LocalDateTime
+
+@UnitTest
+class ApplicantValidatorTest : DescribeSpec({
+
+    val applicantValidator = ApplicantValidator()
+
+    describe("viewableValidator") {
+
+        it("조회 가능 기간 내이면 예외가 발생하지 않는다") {
+            // given
+            val now = LocalDateTime.now()
+            val applicant = ApplicantDataFixture.createViewable(now)
+
+            // when & then
+            shouldNotThrowAny {
+                applicantValidator.viewableValidator(applicant, now)
+            }
+        }
+
+        it("조회 가능 기간이 지났으면 ApplicantViewablePeriodEndException이 발생한다") {
+            // given
+            val now = LocalDateTime.now()
+            val applicant = ApplicantDataFixture.createNotViewable(now)
+
+            // when & then
+            shouldThrow<ApplicantViewablePeriodEndException> {
+                applicantValidator.viewableValidator(applicant, now)
+            }
+        }
+
+        it("조회 가능 기간 시작 전이면 ApplicantViewablePeriodEndException이 발생한다") {
+            // given
+            val now = LocalDateTime.now()
+            val applicant = ApplicantDataFixture.create(
+                period = ac.dnd.server.admission.domain.model.ViewablePeriod.of(
+                    now.plusDays(10),
+                    now.plusDays(20)
+                )
+            )
+
+            // when & then
+            shouldThrow<ApplicantViewablePeriodEndException> {
+                applicantValidator.viewableValidator(applicant, now)
+            }
+        }
+    }
+})

--- a/src/test/kotlin/ac/dnd/server/admission/domain/model/ApplicantDataTest.kt
+++ b/src/test/kotlin/ac/dnd/server/admission/domain/model/ApplicantDataTest.kt
@@ -1,0 +1,89 @@
+package ac.dnd.server.admission.domain.model
+
+import ac.dnd.server.annotation.UnitTest
+import ac.dnd.server.fixture.ApplicantDataFixture
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import java.time.LocalDateTime
+
+@UnitTest
+class ApplicantDataTest : DescribeSpec({
+
+    describe("isViewable") {
+
+        it("현재 시각이 조회 가능 기간 내이면 true를 반환한다") {
+            // given
+            val now = LocalDateTime.now()
+            val applicant = ApplicantDataFixture.createViewable(now)
+
+            // when
+            val result = applicant.isViewable(now)
+
+            // then
+            result shouldBe true
+        }
+
+        it("현재 시각이 조회 가능 기간 이전이면 false를 반환한다") {
+            // given
+            val now = LocalDateTime.now()
+            val applicant = ApplicantDataFixture.create(
+                period = ViewablePeriod.of(
+                    now.plusDays(10),
+                    now.plusDays(20)
+                )
+            )
+
+            // when
+            val result = applicant.isViewable(now)
+
+            // then
+            result shouldBe false
+        }
+
+        it("현재 시각이 조회 가능 기간 이후이면 false를 반환한다") {
+            // given
+            val now = LocalDateTime.now()
+            val applicant = ApplicantDataFixture.createNotViewable(now)
+
+            // when
+            val result = applicant.isViewable(now)
+
+            // then
+            result shouldBe false
+        }
+
+        it("시작 시각과 정확히 같으면 false를 반환한다") {
+            // given
+            val now = LocalDateTime.of(2024, 6, 1, 12, 0)
+            val applicant = ApplicantDataFixture.create(
+                period = ViewablePeriod.of(
+                    now,
+                    now.plusDays(10)
+                )
+            )
+
+            // when
+            val result = applicant.isViewable(now)
+
+            // then
+            result shouldBe false
+        }
+
+        it("종료 시각과 정확히 같으면 false를 반환한다") {
+            // given
+            val now = LocalDateTime.of(2024, 6, 10, 12, 0)
+            val applicant = ApplicantDataFixture.create(
+                period = ViewablePeriod.of(
+                    now.minusDays(10),
+                    now
+                )
+            )
+
+            // when
+            val result = applicant.isViewable(now)
+
+            // then
+            result shouldBe false
+        }
+    }
+})

--- a/src/test/kotlin/ac/dnd/server/fixture/ApplicantDataFixture.kt
+++ b/src/test/kotlin/ac/dnd/server/fixture/ApplicantDataFixture.kt
@@ -1,24 +1,52 @@
 package ac.dnd.server.fixture
 
-import ac.dnd.server.admission.domain.model.ApplicantData
-import ac.dnd.server.admission.domain.model.ViewablePeriod
 import ac.dnd.server.admission.domain.enums.ApplicantStatus
 import ac.dnd.server.admission.domain.enums.ApplicantType
+import ac.dnd.server.admission.domain.model.ApplicantData
+import ac.dnd.server.admission.domain.model.ViewablePeriod
 import java.time.LocalDateTime
 
 object ApplicantDataFixture {
-    fun create(): ApplicantData {
+
+    fun create(
+        id: Long = 1L,
+        eventName: String = "테스트 이벤트",
+        name: String = "홍길동",
+        email: String = "test@test.com",
+        type: ApplicantType = ApplicantType.BACKEND,
+        status: ApplicantStatus = ApplicantStatus.PASSED,
+        period: ViewablePeriod = ViewablePeriod.of(LocalDateTime.MIN, LocalDateTime.MAX)
+    ): ApplicantData {
         return ApplicantData(
-            1L,
-            "테스트 이벤트",
-            "홍길동",
-            "test@test.com",
-            ApplicantType.BACKEND,
-            ApplicantStatus.PASSED,
-            ViewablePeriod.of(
-                LocalDateTime.MIN,
-                LocalDateTime.MAX
+            id = id,
+            eventName = eventName,
+            name = name,
+            email = email,
+            type = type,
+            status = status,
+            period = period
+        )
+    }
+
+    fun createViewable(now: LocalDateTime): ApplicantData {
+        return create(
+            period = ViewablePeriod.of(
+                now.minusDays(10),
+                now.plusDays(10)
             )
         )
+    }
+
+    fun createNotViewable(now: LocalDateTime): ApplicantData {
+        return create(
+            period = ViewablePeriod.of(
+                now.minusDays(20),
+                now.minusDays(10)
+            )
+        )
+    }
+
+    fun createWithStatus(status: ApplicantStatus): ApplicantData {
+        return create(status = status)
     }
 }

--- a/src/test/kotlin/ac/dnd/server/fixture/JwtPropertiesFixture.kt
+++ b/src/test/kotlin/ac/dnd/server/fixture/JwtPropertiesFixture.kt
@@ -1,0 +1,35 @@
+package ac.dnd.server.fixture
+
+import ac.dnd.server.shared.config.properties.JwtProperties
+
+object JwtPropertiesFixture {
+
+    private const val DEFAULT_SECRET = "test-secret-key-for-jwt-token-generation-must-be-at-least-256-bits"
+    private const val DEFAULT_ACCESS_TOKEN_EXPIRATION_HOURS = 1L
+    private const val DEFAULT_REFRESH_TOKEN_EXPIRATION_DAYS = 30L
+
+    fun create(
+        secret: String = DEFAULT_SECRET,
+        accessTokenExpirationHours: Long = DEFAULT_ACCESS_TOKEN_EXPIRATION_HOURS,
+        refreshTokenExpirationDays: Long = DEFAULT_REFRESH_TOKEN_EXPIRATION_DAYS,
+        cookieSecure: Boolean = false,
+        cookieSameSite: String = "Lax"
+    ): JwtProperties {
+        return JwtProperties(
+            secret = secret,
+            accessTokenExpirationHours = accessTokenExpirationHours,
+            refreshTokenExpirationDays = refreshTokenExpirationDays,
+            cookie = JwtProperties.CookieProperties(
+                secure = cookieSecure,
+                sameSite = cookieSameSite
+            )
+        )
+    }
+
+    fun createWithShortExpiration(): JwtProperties {
+        return create(
+            accessTokenExpirationHours = 1L,
+            refreshTokenExpirationDays = 1L
+        )
+    }
+}

--- a/src/test/kotlin/ac/dnd/server/fixture/RefreshTokenFixture.kt
+++ b/src/test/kotlin/ac/dnd/server/fixture/RefreshTokenFixture.kt
@@ -1,0 +1,58 @@
+package ac.dnd.server.fixture
+
+import ac.dnd.server.account.infrastructure.persistence.entity.RefreshToken
+import ac.dnd.server.account.infrastructure.persistence.entity.UserKey
+import java.time.LocalDateTime
+
+object RefreshTokenFixture {
+
+    fun create(
+        userKey: UserKey = UserKey.generate(),
+        token: String = "test-refresh-token",
+        expiresAt: LocalDateTime = LocalDateTime.now().plusDays(30),
+        expired: Boolean = false
+    ): RefreshToken {
+        return RefreshToken(
+            userKey = userKey,
+            token = token,
+            expiresAt = expiresAt,
+            expired = expired
+        )
+    }
+
+    fun createExpiredByTime(
+        userKey: UserKey = UserKey.generate(),
+        token: String = "expired-refresh-token"
+    ): RefreshToken {
+        return RefreshToken(
+            userKey = userKey,
+            token = token,
+            expiresAt = LocalDateTime.now().minusDays(1),
+            expired = false
+        )
+    }
+
+    fun createExpiredByFlag(
+        userKey: UserKey = UserKey.generate(),
+        token: String = "revoked-refresh-token"
+    ): RefreshToken {
+        return RefreshToken(
+            userKey = userKey,
+            token = token,
+            expiresAt = LocalDateTime.now().plusDays(30),
+            expired = true
+        )
+    }
+
+    fun createValid(
+        userKey: UserKey = UserKey.generate(),
+        token: String = "valid-refresh-token"
+    ): RefreshToken {
+        return RefreshToken(
+            userKey = userKey,
+            token = token,
+            expiresAt = LocalDateTime.now().plusDays(30),
+            expired = false
+        )
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,19 +1,4 @@
 spring:
-  datasource:
-    url: jdbc:mysql://localhost:3306/testdb?rewriteBatchedStatements=true&useServerPrepStmts=true
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    username: test
-    password: test
-    hikari:
-      pool-name: MyHikariPool-t4g-micro
-      maximum-pool-size: 4
-      minimum-idle: 4
-      idle-timeout: 600000
-      max-lifetime: 1800000
-      connection-timeout: 20000
-      validation-timeout: 5000
-      auto-commit: true
-
   jpa:
     open-in-view: false
     show-sql: true
@@ -25,10 +10,24 @@ spring:
 
 encryption:
   aes:
-    password: ${ENCRYPTION_TEXT_PASSWORD}
-    salt: ${ENCRYPTION_TEXT_SALT}
+    password: ${ENCRYPTION_TEXT_PASSWORD:testpassword}
+    salt: ${ENCRYPTION_TEXT_SALT:12345678}
   hmac:
-    key: ${HMAC_KEY}
+    key: ${HMAC_KEY:12345678}
+
+jwt:
+  secret: ${JWT_SECRET:testSecretKeyForJwtTokenThatIsLongEnoughForHS256Algorithm}
+  accessTokenExpirationHours: 1
+  refreshTokenExpirationDays: 30
+  cookie:
+    secure: false
+    sameSite: Lax
+
+github:
+  token: ${GITHUB_TOKEN:testtoken}
+  repository:
+    owner: ${GITHUB_REPO_OWNER:testowner}
+    name: ${GITHUB_REPO_NAME:testname}
 
 server:
   port: 8080


### PR DESCRIPTION
- `ApplicantData`, `ApplicantValidator`, `ApplicantQueryService`, `JwtTokenProvider`에 대한 단위 테스트 추가
- 로그인 및 리프레시 토큰 워크플로우에 대한 통합 테스트 도입
- 테스트 자동화 및 커버리지 보고서 개선을 위한 GitHub Actions CI 파이프라인 구성